### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ To have this available to use in your explores and dashboards there are a few st
 2. In the view file where the date dimension you would like to be able to compare is, extend the `_date_comparison` view by adding the parameter `extends: [_date_comparison]`
 3. In the same view file, add two new dimensions, `event_date` and `event_raw`. These are simply `<your_date_dimension>_date` and `<your_date_dimension>_raw` respectively. This step is just so that naming convention used in the `_date_comparison` view works correctly
 3. In the relevant explore LookML, add in the `sql_always_where` clause defined in the model file here. Replace all instances of `<your_view_name>` with your view name.
+
+## Trouble Shooting
+


### PR DESCRIPTION
If you have you connection set up to a timezone and time selected e.g. UTC, US Central Time, Looker will pass additional arguements into the SQL which will error with the existing code. This is due to the use of the Date_sub function. 
The following error will occur:
No matching signature for function FORMAT_TIMESTAMP for argument types: STRING, DATE, STRING. Supported signature: FORMAT_TIMESTAMP(STRING, TIMESTAMP, [STRING]) at 

A quick fix is to add "convert_tz: no" to each field with a type: date, time, date_time
This prevents looker from converting the database timezone to what you have set up in your connection. 
If you wish to have the database timezone converted, you will need to replace the date_sub function.